### PR TITLE
feat(gh): add GitHub CLI and gh-dash configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -165,11 +165,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775622785,
-        "narHash": "sha256-/yFxO+7oS1SymDfJ2iVO7K5vJKcYfe9XGIJ+quLqz0Q=",
+        "lastModified": 1775683737,
+        "narHash": "sha256-oBYyowo6yfgb95Z78s3uTnAd9KkpJpwzjJbfnpLaM2Y=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "527e47b78fe67213072f706bf933a9705a8c4974",
+        "rev": "7ba4ee4228ed36123c7cb75d50524b43514ef992",
         "type": "github"
       },
       "original": {
@@ -190,11 +190,11 @@
         "xwayland-satellite-unstable": "xwayland-satellite-unstable"
       },
       "locked": {
-        "lastModified": 1775637310,
-        "narHash": "sha256-LYm11N3gAH8bnQcU+/bIyeE1YAFOUuaJ5LQQgI1VB3E=",
+        "lastModified": 1775710668,
+        "narHash": "sha256-pi2TWoWZR22vzr5RBAgIdl1LDwgLX+fh+Hqngt/Kkt8=",
         "owner": "sodiboo",
         "repo": "niri-flake",
-        "rev": "15223527082d596609717cacf10a8b2d51c8787d",
+        "rev": "bef414577a6a745543989716df478afec96486bd",
         "type": "github"
       },
       "original": {
@@ -243,11 +243,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775617217,
-        "narHash": "sha256-Fm3ZL642Ox/B8k+Dv3dxwTxwZfL/62eyPY6meQnd6XQ=",
+        "lastModified": 1775703285,
+        "narHash": "sha256-Dck/lX920n3ClC6U2m3fWaXgoGrtJpnqfGCdiOb8Gf4=",
         "owner": "nix-community",
         "repo": "nix-vscode-extensions",
-        "rev": "939679c08d18ddcbddbcb8dd74411a0d84213484",
+        "rev": "c2281bf25d05ecb8155319456340afd34bea28ec",
         "type": "github"
       },
       "original": {
@@ -274,11 +274,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1775525138,
-        "narHash": "sha256-BQb70+B378ECLO8iQT3P/b1hCC5/CJVHZdeulY8futc=",
+        "lastModified": 1775595990,
+        "narHash": "sha256-OEf7YqhF9IjJFYZJyuhAypgU+VsRB5lD4DuiMws5Ltc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d96b37bbeb9840f1c0ebfe90585ef5067b69bbb3",
+        "rev": "4e92bbcdb030f3b4782be4751dc08e6b6cb6ccf2",
         "type": "github"
       },
       "original": {
@@ -332,11 +332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775619836,
-        "narHash": "sha256-VcC/+MMMldwQKcST2y/QTndGLusSxjeUvYwFwzZKKko=",
+        "lastModified": 1775682595,
+        "narHash": "sha256-0E9PohY/VuESLq0LR4doaH7hTag513sDDW5n5qmHd1Q=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "de5f2d596eb896a5728afcd15f823f59cb9ecfdb",
+        "rev": "d2e8438d5886e92bc5e7c40c035ab6cae0c41f76",
         "type": "github"
       },
       "original": {
@@ -480,11 +480,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1775454133,
-        "narHash": "sha256-LpZpT4zC8keRMkV5jLh0dpgSFoDgFaSpdSlJxxwzHoI=",
+        "lastModified": 1775717994,
+        "narHash": "sha256-KtYecK2ptWv1cOwuC8fYpZJueuPZGjy+1T5WvcPd3gk=",
         "owner": "hambosto",
         "repo": "wallpaper-rs",
-        "rev": "cafc3b68504350ef5ebe241c5a1de9aad3339e5d",
+        "rev": "10ec10f01221c60a4c5953af437b274a3814a276",
         "type": "github"
       },
       "original": {

--- a/home-manager/programs/default.nix
+++ b/home-manager/programs/default.nix
@@ -13,6 +13,7 @@
     ./fastfetch.nix
     ./fish.nix
     ./fzf.nix
+    ./gh.nix
     ./ghostty.nix
     ./git.nix
     ./go.nix

--- a/home-manager/programs/gh.nix
+++ b/home-manager/programs/gh.nix
@@ -1,0 +1,132 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  programs.gh = {
+    enable = true;
+    settings = {
+      git_protocol = "ssh";
+      editor = "hx";
+    };
+  };
+
+  programs.gh-dash = {
+    enable = config.programs.gh.enable;
+    settings = {
+      prSections = [
+        {
+          title = "My Pull Requests";
+          filters = "is:open author:@me";
+          type = null;
+        }
+        {
+          title = "Needs My Review";
+          filters = "is:open review-requested:@me";
+          type = null;
+        }
+        {
+          title = "Involved";
+          filters = "is:open involves:@me -author:@me";
+          type = null;
+        }
+      ];
+      issuesSections = [
+        {
+          title = "My Issues";
+          filters = "is:open author:@me";
+        }
+        {
+          title = "Assigned";
+          filters = "is:open assignee:@me";
+        }
+        {
+          title = "Involved";
+          filters = "is:open involves:@me -author:@me";
+        }
+      ];
+
+      repo = {
+        branchesRefetchIntervalSeconds = 30;
+        prsRefetchIntervalSeconds = 60;
+      };
+      defaults = {
+        preview = {
+          open = true;
+          width = 50;
+        };
+        prsLimit = 20;
+        prApproveComment = "LGTM";
+        issuesLimit = 20;
+        view = "prs";
+        layout = {
+          prs = {
+            updatedAt = {
+              width = 5;
+            };
+            createdAt = {
+              width = 5;
+            };
+            repo = {
+              width = 20;
+            };
+            author = {
+              width = 15;
+            };
+            authorIcon = {
+              hidden = false;
+            };
+            assignees = {
+              width = 20;
+              hidden = true;
+            };
+            base = {
+              width = 15;
+              hidden = true;
+            };
+            lines = {
+              width = 15;
+            };
+          };
+          issues = {
+            updatedAt = {
+              width = 5;
+            };
+            createdAt = {
+              width = 5;
+            };
+            repo = {
+              width = 15;
+            };
+            creator = {
+              width = 10;
+            };
+            creatorIcon = {
+              hidden = false;
+            };
+            assignees = {
+              width = 20;
+              hidden = true;
+            };
+          };
+        };
+        refetchIntervalMinutes = 30;
+      };
+      keybindings = {
+        universal = [ ];
+        issues = [ ];
+        prs = [ ];
+        branches = [ ];
+      };
+      repoPaths = { };
+      pager = {
+        diff = "${lib.getExe pkgs.diffnav}";
+      };
+      confirmQuit = false;
+      showAuthorIcons = true;
+      smartFilteringAtLaunch = true;
+    };
+  };
+}

--- a/home-manager/secrets/default.nix
+++ b/home-manager/secrets/default.nix
@@ -27,7 +27,7 @@ in
           tomlFormat.generate "config.toml" {
             api = {
               key = config.sops.placeholder.gemini;
-              model = "gemini-2.5-flash";
+              model = "gemini-3-flash-preview";
             };
             behavior = {
               auto_select = false;

--- a/home-manager/secrets/default.nix
+++ b/home-manager/secrets/default.nix
@@ -1,11 +1,13 @@
 {
   config,
   inputs,
+  lib,
   pkgs,
   ...
 }:
 let
   tomlFormat = pkgs.formats.toml { };
+  yamlFormat = pkgs.formats.yaml { };
 in
 {
   imports = [ inputs.sops-nix.homeManagerModules.sops ];
@@ -16,32 +18,53 @@ in
 
     secrets = {
       gemini = { };
+      gh-oauth-token = lib.mkIf config.programs.gh.enable { };
     };
 
-    templates.geminicommit = {
-      content = builtins.readFile (
-        tomlFormat.generate "config.toml" {
-          api = {
-            key = config.sops.placeholder.gemini;
-            model = "gemini-2.5-flash";
-          };
-          behavior = {
-            auto_select = false;
-            dry_run = false;
-            no_confirm = false;
-            no_verify = false;
-            push = false;
-            quiet = false;
-            show_diff = false;
-            stage_all = false;
-          };
-          commit = {
-            language = "english";
-            max_length = 72;
-          };
-        }
-      );
-      path = "${config.xdg.configHome}/geminicommit/config.toml";
+    templates = {
+      geminicommit = {
+        content = builtins.readFile (
+          tomlFormat.generate "config.toml" {
+            api = {
+              key = config.sops.placeholder.gemini;
+              model = "gemini-2.5-flash";
+            };
+            behavior = {
+              auto_select = false;
+              dry_run = false;
+              no_confirm = false;
+              no_verify = false;
+              push = false;
+              quiet = false;
+              show_diff = false;
+              stage_all = false;
+            };
+            commit = {
+              language = "english";
+              max_length = 72;
+            };
+          }
+        );
+        path = "${config.xdg.configHome}/geminicommit/config.toml";
+      };
+
+      gh = lib.mkIf config.programs.gh.enable {
+        content = builtins.readFile (
+          yamlFormat.generate "hosts.yml" {
+            "github.com" = {
+              users = {
+                hambosto = {
+                  oauth_token = config.sops.placeholder.gh-oauth-token;
+                };
+              };
+              git_protocol = "ssh";
+              oauth_token = config.sops.placeholder.gh-oauth-token;
+              user = "hambosto";
+            };
+          }
+        );
+        path = "${config.xdg.configHome}/gh/hosts.yml";
+      };
     };
   };
 }

--- a/secrets/secrets.yaml
+++ b/secrets/secrets.yaml
@@ -1,5 +1,6 @@
 gemini: ENC[AES256_GCM,data:HW68rhzTVyZ+QO5mcWJPix6foYEC+2M9otvqhASoYWfpHaJhILKV,iv:r9B1eKXtaeuxqE6c2Eh28Mhp1cPcMUxgfeZ6CFZn1TM=,tag:FP7VAnbTR/pT4mlt10v0eA==,type:str]
 hashed-password: ENC[AES256_GCM,data:Sh4hJvPRzQkHc6uMmRC1JPe+JngqWHCAfUhPB4/2zemSKP7N/m0OvKG109Rxz4b/YsdOsBcHS+cTslcYpANEkWsEgKN07D731RZK7LfzzN9l3FTVg0XJ2QzywHCCX7kscc1K46jNbsbbfw==,iv:dIR6Zb4nyeZ9/l/C9YDJFXJe/5b+l/Uc4NrDDN5JTYU=,tag:udXFHEXIH/NRRneZypbopQ==,type:str]
+gh-oauth-token: ENC[AES256_GCM,data:Hh94JysnX4smIZCQDB62MJefErciK8oeYon2uvfp7DrFRTqDWpXrkA==,iv:G8c0tBYZwWQU3kdwyk9mp9eHzhHSfOTgdSmuHQ3bVV8=,tag:6FtbGT5BOTIusTU0xIobmg==,type:str]
 sops:
     age:
         - recipient: age1qlfnxurcqh2qk2wlnwslrg9va9wn4ccetarpu7m59leqxjzx9g4sph747u
@@ -11,7 +12,7 @@ sops:
             MkRvL0FtRE5LVEtQbXQzTUhEMFVrOWcKBPT8vCkBTgRnNMtXEpVN2XuD2HFwE146
             WjlyhRRwYbB8FVGt9ZHLpGbckuJOSNEemNyERhI1zNc23oRd082W9g==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-04-08T13:42:41Z"
-    mac: ENC[AES256_GCM,data:/YRzPJxo7SOel5a4//0yrf2W25kP9YjsRooTLGFHqFBl4CGPw4gLdP3S0ZGa4Q9Z1H/GzKrxJCXLlLWMeDhmJcK3cnrKNDhUVfPXPy179qO3Unl5EEppObenKTcJiVKMjy8LYORgw2sqMoLIGOppwyRlOkzAlrX+AG6UVIuchq8=,iv:hPPzrfoV0gG0Ji1A3Yv19qXqfLdYEUWzcR9zNTNiBdg=,tag:NTZnNF1FugHuZVS1giaBeQ==,type:str]
+    lastmodified: "2026-04-09T07:37:21Z"
+    mac: ENC[AES256_GCM,data:zuEFx3UiQ5MfbtE4C0Oj2Oo/EpPgQQ8VsAVruF18uJM4yt29tPojJOiGpYZulldRXbOCE5L95rFZ7SNT3fe+FvDOxcEh4HntbjCG3TlxdAO3gKH3sP4sLBIHvx+QnWRtGfqKT7OBb0ZsIfElwZ1K3w37y3U7kpdkdXD98weAWQM=,iv:ZJzJh8rfI1pIMgMsFB10lmWQFLYJch4hb3MmfgkiDhA=,tag:6Ji55Odp3YnDTmFVCqmF1Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.12.2


### PR DESCRIPTION
Configure \`gh\` and \`gh-dash\` with custom layouts and PR/issue sections. Integrate \`gh-oauth-token\` via sops. Update \`geminicommit\` model and bump flake dependencies.